### PR TITLE
Improve error handling of benchmarks

### DIFF
--- a/benchmark_tiny.txt
+++ b/benchmark_tiny.txt
@@ -1,0 +1,6 @@
+# Halide fails on all of these
+1x1x1
+4x4x4
+4x4x16
+1x16x16
+16x16x16

--- a/matmul/main.cc
+++ b/matmul/main.cc
@@ -127,6 +127,8 @@ int main(int argc, char **argv) {
   }
   t_end = rtclock();
 
+  int return_code = 0;
+
 #ifdef ENABLE_CHECK
   float *C2 = (float *) malloc(MDIM * NDIM * sizeof(float));
   size_t errors = 0;
@@ -141,6 +143,7 @@ int main(int argc, char **argv) {
     }
   }
   printf("Detected %ld errors.\n", errors);
+  return_code = 1;
 #endif
 
   const char *filename = TO_STRING(FILE_NAME);
@@ -153,5 +156,5 @@ int main(int argc, char **argv) {
   free(B);
   free(C);
 #endif
-  return 0;
+  return return_code;
 }


### PR DESCRIPTION
* Report error code 1 if matrix verification failed.
* If the benchmark process fails, report the error and continue.
* Return error code 1 if there was a problem with any benchmark.