### PR TITLE
Add support to run dynamic matmul shapes in IREE backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,13 @@ ExternalProject_Add(tvm
 list(APPEND MATMUL_DEPS tvm)
 endif()
 
+set(MATMUL_CMAKE_ARGS "")
+foreach(var IN LISTS VARS_TO_COPY)
+    list(APPEND MATMUL_CMAKE_ARGS -D${var}=${${var}})
+endforeach()
+
 if(${USE_IREE} STREQUAL "ON")
-set(EXTERNAL_DIR ${CMAKE_SOURCE_DIR}/external/iree)
+set(IREE_SOURCE ${CMAKE_SOURCE_DIR}/external/iree)
 ExternalProject_Add(matmul-iree
   PREFIX ${CMAKE_BINARY_DIR}/matmul-iree
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/matmul-iree
@@ -119,15 +124,11 @@ ExternalProject_Add(matmul-iree
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON
-    -DIREE_SRC=${EXTERNAL_DIR}
+    -DIREE_SOURCE=${IREE_SOURCE}
+    ${MATMUL_CMAKE_ARGS}
 )
 # list(APPEND MATMUL_DEPS iree)
 endif()
-
-set(MATMUL_CMAKE_ARGS "")
-foreach(var IN LISTS VARS_TO_COPY)
-    list(APPEND MATMUL_CMAKE_ARGS -D${var}=${${var}})
-endforeach()
 
 ExternalProject_Add(matmul
   DEPENDS ${MATMUL_DEPS}

--- a/matmul-iree/CMakeLists.txt
+++ b/matmul-iree/CMakeLists.txt
@@ -8,11 +8,8 @@ project(matmul-iree VERSION 1.0 LANGUAGES CXX C)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-# NOTE: The RTTI setting must match what LLVM was compiled with and IREE
-#       defaults to RTTI disabled in `iree_copts.cmake`.
-#       RTTI is disabled for `dialect` target, but you may want to consider to
-#       to pass `-fno-rtti` as a global compile option by adding the line
-# add_compile_options(-fno-rtti)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake/")
+include(common)
 
 #-------------------------------------------------------------------------------
 # Third-party dependencies
@@ -21,7 +18,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Extend module path to allow submodules to find AddMLIR
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_BINARY_DIR}/lib/cmake/mlir")
 
-add_subdirectory(${IREE_SRC} iree EXCLUDE_FROM_ALL)
+add_subdirectory(${IREE_SOURCE} iree EXCLUDE_FROM_ALL)
 
 #-------------------------------------------------------------------------------
 # Top-level components

--- a/matmul-iree/src/CMakeLists.txt
+++ b/matmul-iree/src/CMakeLists.txt
@@ -1,98 +1,122 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Generate MLIR artifacts of specified sizes
+function(compile_mlir mlir_prefix M N K)
+    configure_file(${CMAKE_SOURCE_DIR}/src/matmul_MxNxK.mlir ${CMAKE_BINARY_DIR}/mlir-objs/${mlir_prefix}.mlir)
+endfunction()
 
-#-------------------------------------------------------------------------------
+# Matrix sizes to benchmark
+message(STATUS "Reading matrix sizes from ... ${SIZE_FILE}")
+file(READ ${SIZE_FILE} MATRIX_SIZES)
+string(REGEX REPLACE "#[^\n]*\n" "" MATRIX_SIZES "${MATRIX_SIZES}")
+string(REGEX REPLACE ";" "\\\\;" MATRIX_SIZES "${MATRIX_SIZES}")
+string(REGEX REPLACE "\n" ";" MATRIX_SIZES "${MATRIX_SIZES}")
+
 # Use `iree-translate` to transform an MLIR file into an VM bytcode module.
-#-------------------------------------------------------------------------------
-
 # Resolve the executable binary path for iree-translate from the target name.
 set(_TRANSLATE_TOOL_EXECUTABLE $<TARGET_FILE:iree_tools_iree-translate>)
 
-# Define arguments passed to iree-translate
-set(_ARGS)
-list(APPEND _ARGS "-iree-input-type=mhlo")
-list(APPEND _ARGS "-iree-mlir-to-vm-bytecode-module")
-list(APPEND _ARGS "-iree-hal-target-backends=vmvx")
-# Uncomment the line below to use vulkan-spirv backend
-#list(APPEND _ARGS "-iree-hal-target-backends=vulkan-spirv")
-list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/matmul.mlir")
-list(APPEND _ARGS "-o")
-list(APPEND _ARGS "matmul.vmfb")
+message(STATUS "Generating mhlo.dot mlir files...")
+foreach(MATRIX_SIZE ${MATRIX_SIZES})
+  if ("${MATRIX_SIZE}" STREQUAL "")
+    continue()
+  endif()
 
-# Translate MLIR file to VM bytecode module
-add_custom_command(
-  OUTPUT "matmul.vmfb"
-  COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_ARGS}
-  DEPENDS iree_tools_iree-translate
-)
+  string(CONCAT MATMUL "matmul_" ${MATRIX_SIZE})
+  message(STATUS "Compiling ${MATMUL}")
 
-#-------------------------------------------------------------------------------
-# Embedd the VM bytcode module into a c file via `generate_embed_data`.
-#-------------------------------------------------------------------------------
+  string(REPLACE "x" ";" SIZES ${MATRIX_SIZE})
+  list(GET SIZES 0 M)
+  list(GET SIZES 1 N)
+  list(GET SIZES 2 K)
 
-# Define arguments passed to generate_embed_data
-set(_ARGS)
-list(APPEND _ARGS "--output_header=matmul.h")
-list(APPEND _ARGS "--output_impl=matmul.c")
-list(APPEND _ARGS "--identifier=matmul")
-list(APPEND _ARGS "--flatten")
-list(APPEND _ARGS "matmul.vmfb")
+  compile_mlir(${MATMUL} ${M} ${N} ${K})
 
-# Embed VM bytecode module into c source file
-add_custom_command(
-  OUTPUT
-    "matmul.h"
-    "matmul.c"
-  COMMAND generate_embed_data ${_ARGS}
-  DEPENDS generate_embed_data matmul.vmfb
-)
+  set(MATMUL_MLIR_FILE ${CMAKE_BINARY_DIR}/mlir-objs/${MATMUL}.mlir)
 
+  #-------------------------------------------------------------------------------
+  # Use `iree-translate` to transform an MLIR file into an VM bytcode module.
+  #-------------------------------------------------------------------------------
 
-#-------------------------------------------------------------------------------
-# Create a library and thus a CMake target.
-#-------------------------------------------------------------------------------
+  # Define arguments passed to iree-translate
+  set(_ARGS)
+  list(APPEND _ARGS "-iree-input-type=mhlo")
+  list(APPEND _ARGS "-iree-mlir-to-vm-bytecode-module")
+  list(APPEND _ARGS "-iree-hal-target-backends=vmvx")
+  # Uncomment the line below to use vulkan-spirv backend
+  #list(APPEND _ARGS "-iree-hal-target-backends=vulkan-spirv")
+  list(APPEND _ARGS "${MATMUL_MLIR_FILE}")
+  list(APPEND _ARGS "-o")
+  list(APPEND _ARGS "${MATMUL}.vmfb")
 
-add_library(matmul_c STATIC "")
-target_sources(matmul_c
-  PRIVATE
-    matmul.c
-    matmul.h
-)
+  # Translate MLIR file to VM bytecode module
+  add_custom_command(
+    OUTPUT "${MATMUL}.vmfb"
+    COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_ARGS}
+    DEPENDS iree_tools_iree-translate
+  )
 
+  #-------------------------------------------------------------------------------
+  # Embedd the VM bytcode module into a c file via `generate_embed_data`.
+  #-------------------------------------------------------------------------------
 
-#-------------------------------------------------------------------------------
-# Build the excutable.
-#-------------------------------------------------------------------------------
+  # Define arguments passed to generate_embed_data
+  set(_ARGS)
+  list(APPEND _ARGS "--output_header=${MATMUL}.h")
+  list(APPEND _ARGS "--output_impl=${MATMUL}.c")
+  list(APPEND _ARGS "--identifier=matmul")
+  list(APPEND _ARGS "--flatten")
+  list(APPEND _ARGS "${MATMUL}.vmfb")
 
-add_executable(matmul_generator "")
-target_sources(matmul_generator
-  PRIVATE
-  matmul_generator.c
+  # Embed VM bytecode module into c source file
+  add_custom_command(
+    OUTPUT
+      "${MATMUL}.h"
+      "${MATMUL}.c"
+    COMMAND generate_embed_data ${_ARGS}
+    DEPENDS generate_embed_data ${MATMUL}.vmfb
+  )
+
+  #-------------------------------------------------------------------------------
+  # Create a library and thus a CMake target.
+  #-------------------------------------------------------------------------------
+  string(CONCAT MLIR_LIB ${MATMUL} "_c")
+  add_library(${MLIR_LIB} STATIC "")
+  target_sources(${MLIR_LIB}
+    PRIVATE
+    ${MATMUL}.c
+    ${MATMUL}.h
+  )
+
+  #-------------------------------------------------------------------------------
+  # Build the excutable.
+  #-------------------------------------------------------------------------------
+  add_executable(${MATMUL} "")
+  target_sources(${MATMUL}
+    PRIVATE
+    matmul_generator.c
     device_vmvx.c
-)
+  )
 
-set_target_properties(matmul_generator PROPERTIES OUTPUT_NAME matmul_generator)
+  set_target_properties(${MATMUL} PROPERTIES OUTPUT_NAME ${MATMUL})
 
-target_include_directories(matmul_generator
-  PUBLIC
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
+  target_include_directories(${MATMUL}
+    PUBLIC
+      ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
-target_link_libraries(matmul_generator
-  matmul_c
-  iree_base_base
-  iree_hal_hal
-  iree_hal_vmvx_registration_registration
-  iree_modules_hal_hal
-  iree_vm_vm
-  iree_vm_bytecode_module
-)
+  target_link_libraries(${MATMUL}
+    ${MLIR_LIB}
+    iree_base_base
+    iree_hal_hal
+    iree_hal_vmvx_registration_registration
+    iree_modules_hal_hal
+    iree_vm_vm
+    iree_vm_bytecode_module
+  )
+
+  target_compile_definitions(${MATMUL}
+   PRIVATE "MATMUL_HEADER=\"${MATMUL}.h\"")
+  target_compile_definitions(${MATMUL} PRIVATE MDIM=${M})
+  target_compile_definitions(${MATMUL} PRIVATE NDIM=${N})
+  target_compile_definitions(${MATMUL} PRIVATE KDIM=${K})
+
+endforeach()

--- a/matmul-iree/src/matmul.mlir
+++ b/matmul-iree/src/matmul.mlir
@@ -1,7 +1,0 @@
-func @matmul() -> tensor<2x2xf32>
-    {
-    %arg0 = constant dense<[[1.], [2.]]> : tensor<2x1xf32>
-    %arg1 = constant dense<[[3., 4.]]> : tensor<1x2xf32>
-    %0 = "mhlo.dot"(%arg0, %arg1) {name = "dot0"} : (tensor<2x1xf32>, tensor<1x2xf32>) -> tensor<2x2xf32>
-    return %0 : tensor<2x2xf32>
-}

--- a/matmul-iree/src/matmul_MxNxK.mlir
+++ b/matmul-iree/src/matmul_MxNxK.mlir
@@ -1,0 +1,5 @@
+func @matmul(%arg0: tensor<${M}x${K}xf32>, %arg1: tensor<${K}x${N}xf32>) -> tensor<${M}x${N}xf32>
+    {
+    	%0 = "mhlo.dot"(%arg0, %arg1) {name = "dot0"} : (tensor<${M}x${K}xf32>, tensor<${K}x${N}xf32>) -> tensor<${M}x${N}xf32>
+    	return %0 : tensor<${M}x${N}xf32>
+}


### PR DESCRIPTION
This PR adds support to extract matmul shapes from benchmark list and generate an executable for each using IREE (currently supports vmvx backend).  