### PR TITLE
Add IREE Tiling pass

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -39,7 +39,7 @@ endif()
 if(${USE_IREE})
   option(IREE_VMVX "Enable IREE vmvx (CPU) backend" OFF)
   option(IREE_DYLIB "Enable IREE dylib (CPU) backend" ON)
-  option(IREE_CUDA "Enable IREE cuda (GPU) backend" ON)
+  option(IREE_CUDA "Enable IREE cuda (GPU) backend" OFF)
 endif()
 
 set(VARS_TO_COPY

--- a/matmul-iree/CMakeLists.txt
+++ b/matmul-iree/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.18)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 
 #-------------------------------------------------------------------------------
 # Project configuration
@@ -17,7 +18,6 @@ include(common)
 
 # Extend module path to allow submodules to find AddMLIR
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_BINARY_DIR}/lib/cmake/mlir")
-
 add_subdirectory(${IREE_SOURCE} iree EXCLUDE_FROM_ALL)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)

--- a/matmul-iree/src/CMakeLists.txt
+++ b/matmul-iree/src/CMakeLists.txt
@@ -40,3 +40,5 @@ foreach(MATRIX_SIZE ${MATRIX_SIZES})
   endif()
   
 endforeach()
+
+add_subdirectory(tiling)

--- a/matmul-iree/src/tiling/CMakeLists.txt
+++ b/matmul-iree/src/tiling/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Build flatbuffer tools
+include_directories(${CMAKE_BINARY_DIR}/../flatbuffers-install/include)
+include_directories(${CMAKE_BINARY_DIR}/../fbs/)
+add_custom_command(OUTPUT compile_options_generated.h
+  COMMAND ${CMAKE_BINARY_DIR}/../flatbuffers-install/bin/flatc
+  --cpp --gen-object-api --raw-binary -o ${CMAKE_BINARY_DIR}/../fbs/
+  ${CMAKE_CURRENT_SOURCE_DIR}/compile_options.fbs
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/compile_options.fbs
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+add_custom_target(run ALL DEPENDS compile_options_generated.h)
+
+# Build tool to compile mlir
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_BINARY_DIR}/iree/third_party/llvm-project/llvm/lib/cmake/llvm")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_BINARY_DIR}/lib/cmake/mlir")
+
+include(AddLLVM)
+include(AddMLIR)
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+include_directories(${iree_SOURCE_DIR})
+include_directories(${iree_SOURCE_DIR}/third_party/llvm-project/llvm/include)
+include_directories(${iree_SOURCE_DIR}/third_party/llvm-project/mlir/include)
+include_directories(${iree_SOURCE_DIR}/third_party/mlir-hlo/include)
+include_directories(${iree_BINARY_DIR}/third_party/llvm-project/llvm/include)
+include_directories(${iree_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
+include_directories(${iree_BINARY_DIR})
+
+set(LIBS
+  ${dialect_libs}
+  ${conversion_libs}
+  MLIRExecutionEngine
+  LLVMX86AsmParser
+  iree::compiler::Codegen::Utils
+  iree::compiler::Dialect::HAL::IR
+  iree::compiler::Dialect::HAL::IR::HALDialect
+)
+
+add_llvm_executable(add-tiling-attribute-pass add-tiling-attribute-pass.cpp)
+add_dependencies(add-tiling-attribute-pass run)
+llvm_update_compile_flags(add-tiling-attribute-pass)
+target_link_libraries(add-tiling-attribute-pass PRIVATE ${LIBS})
+mlir_check_all_link_libraries(add-tiling-attribute-pass)

--- a/matmul-iree/src/tiling/add-tiling-attribute-pass.cpp
+++ b/matmul-iree/src/tiling/add-tiling-attribute-pass.cpp
@@ -1,0 +1,217 @@
+// Copyright 2021 Nod Labs
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "mlir/ExecutionEngine/OptUtils.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+#include "mlir/Parser.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Target/LLVMIR/ModuleTranslation.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <iostream>
+
+#include "flatbuffers/flatbuffers.h"
+#include "compile_options_generated.h"
+
+using namespace mlir;
+
+using llvm::Error;
+using llvm::Expected;
+using llvm::StringError;
+using llvm::Twine;
+
+namespace mlir {
+
+namespace {
+namespace cl = llvm::cl;
+struct Options {
+  cl::opt<std::string> inputFile{cl::Positional,
+    cl::desc("the input .mlir file"),
+    cl::init("")};
+
+  // Codegen info
+  cl::opt<std::string> compileOptions{"compile-options", cl::Required,
+    cl::desc("Flatbuffer file describing compile options configurations"),
+    cl::init("empty_file_name")};
+};
+}
+
+namespace {
+template<typename T>
+void populateSmallVector(std::vector<T> vec, SmallVector<T, 4> &smallvec) {
+  for (auto el : vec) {
+    smallvec.push_back(el);
+  }
+}
+
+// Adds lowering.config attribute to mhlo.dot op for tiling
+struct AddTiling : public OpRewritePattern<mhlo::DotOp> {
+  using OpRewritePattern<mhlo::DotOp>::OpRewritePattern;
+
+  AddTiling(MLIRContext *ctx, iree_compiler::TileSizesListType _tileSizes, SmallVector<int64_t, 4> _nativeVectorSizes) : OpRewritePattern<mhlo::DotOp>(ctx), tileSizes(_tileSizes), nativeVectorSizes(_nativeVectorSizes) {}
+  LogicalResult matchAndRewrite(mhlo::DotOp op, PatternRewriter &rewriter) const override {
+    // exit if op already has lowering.config attribute
+    if (op->hasAttr("lowering.config")) {
+      return failure();
+    }
+    // Set lowering config
+    OpBuilder builder(op->getContext());
+    ArrayAttr tileSizesAttr = nullptr;
+    if (!tileSizes.empty()) {
+      auto attrList = llvm::to_vector<4>(
+          llvm::map_range(tileSizes, [&](ArrayRef<int64_t> sizes) -> Attribute {
+            return builder.getI64ArrayAttr(sizes);
+          }));
+      tileSizesAttr = builder.getArrayAttr(attrList);
+    }
+    ArrayAttr nativeVectorSizesAttr = nullptr;
+    if (!nativeVectorSizes.empty()) {
+      nativeVectorSizesAttr = builder.getI64ArrayAttr(nativeVectorSizes);
+    }
+    iree_compiler::IREE::HAL::DispatchLoweringPassPipeline passPipeline =
+      iree_compiler::IREE::HAL::DispatchLoweringPassPipeline::CPUTensorToVectors;
+    auto passPipelineAttr = builder.getStringAttr("CPUTensorToVectors");
+    auto config = iree_compiler::IREE::HAL::LoweringConfig::get(tileSizesAttr, nativeVectorSizesAttr,
+                    /*passPipeline=*/passPipelineAttr, /*workgroupSize=*/nullptr, op->getContext());
+    iree_compiler::setLoweringConfig(op, config);
+    return success();
+  }
+  iree_compiler::TileSizesListType tileSizes;
+  SmallVector<int64_t, 4> nativeVectorSizes;
+};
+
+struct IREETilingPass : public PassWrapper<IREETilingPass, OperationPass<ModuleOp>> {
+  IREETilingPass() = default;
+  IREETilingPass(Options &options) {
+    params.compileOptions = options.compileOptions;
+  }
+  IREETilingPass(const IREETilingPass &pass) {
+    params = pass.params;
+  }
+
+  void runOnOperation() override {
+    // Load CompileOptions from file
+    std::ifstream infile;
+    infile.open(params.compileOptions, std::ios::binary | std::ios::in);
+    infile.seekg(0,std::ios::end);
+    int length = infile.tellg();
+    if (length < 0) {
+     std::cout << "File not found!" << std::endl;
+     std::cout << params.compileOptions << std::endl;
+      exit(1);
+    }
+    infile.seekg(0,std::ios::beg);
+    char *data = new char[length];
+    infile.read(data, length);
+    infile.close();
+    Nod::GetTileOptions(data)->UnPackTo(&config);
+
+    // Set tiling vectors
+    SmallVector<int64_t, 4> workGroupSizes, cacheTileSizes, nativeVectorSizes;
+    populateSmallVector<int64_t>(config.work_group_sizes, workGroupSizes);
+    populateSmallVector<int64_t>(config.cache_tile_sizes, cacheTileSizes);
+    populateSmallVector<int64_t>(config.register_tile_sizes, nativeVectorSizes);
+    iree_compiler::TileSizesListType tileSizes = {workGroupSizes, cacheTileSizes, nativeVectorSizes};
+
+    // Appy pattern rewrite to add lowering.config attribute to mhlo.dot op
+    auto moduleOp = getOperation();
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns(&getContext());
+    patterns.insert<AddTiling>(context, tileSizes, nativeVectorSizes);
+    if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+
+  struct Parameters {
+    std::string compileOptions;
+  };
+  Parameters params;
+  Nod::TileOptionsT config;
+};
+}  // namespace
+
+// pass registration
+std::unique_ptr<OperationPass<ModuleOp>> createIREETilingPass(Options &options) {
+    return std::make_unique<IREETilingPass>(options);
+}
+}
+
+//===----------------------------------------------------------------------===//
+
+/// Wrap a string into an llvm::StringError.
+static Error make_string_error(const Twine &message) {
+  return llvm::make_error<llvm::StringError>(message.str(), llvm::inconvertibleErrorCode());
+}
+
+Error compile(Options &options, mlir::DialectRegistry &registry) {
+  MLIRContext context(registry);
+  context.loadAllAvailableDialects();
+  context.allowUnregisteredDialects();
+
+  llvm::errs() << "Read file: " << options.inputFile << "\n";
+  OwningModuleRef moduleRef = parseSourceFile(options.inputFile, &context);
+  if (!moduleRef)
+    return make_string_error(Twine("could not open ") + options.inputFile);
+
+  ModuleOp module = *moduleRef;
+  PassManager pm(&context);
+  pm.addPass(createIREETilingPass(options));
+
+  if (failed(pm.run(module))) {
+    return make_string_error(Twine("error compiling to llvm backend"));
+  }
+
+  std::string moduleStr;
+  llvm::raw_string_ostream ss(moduleStr);
+  ss << *module;
+
+  std::string name = std::filesystem::path(std::string(options.inputFile)).stem();
+  name += "-tiled.mlir";
+  std::ofstream output(name);
+  output << moduleStr;
+  output.close();
+
+  return Error::success();
+}
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  mlir::registerAllDialects(registry);
+
+  llvm::InitLLVM y(argc, argv);
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  llvm::InitializeNativeTargetAsmParser();
+  mlir::initializeLLVMPasses();
+  mlir::registerAsmPrinterCLOptions();
+  mlir::registerPassManagerCLOptions();
+
+  Options options;
+  llvm::cl::ParseCommandLineOptions(argc, argv, "matmul-iree-compile\n");
+
+  auto error = compile(options, registry);
+  int exitCode = EXIT_SUCCESS;
+  llvm::handleAllErrors(std::move(error), [&exitCode](const llvm::ErrorInfoBase &info) {
+    llvm::errs() << "Error: ";
+    info.log(llvm::errs());
+    llvm::errs() << '\n';
+    exitCode = EXIT_FAILURE;
+  });
+  return exitCode;
+}

--- a/matmul-iree/src/tiling/compile_options.fbs
+++ b/matmul-iree/src/tiling/compile_options.fbs
@@ -1,0 +1,12 @@
+namespace Nod;
+
+// Iree tiling interface has 3 levels of tiling
+// 1) work group sizes: used for parallelizing spatial loops (2 sizes for matmul)
+// 2) cache tile sizes: used for cache tiling (3 sizes for matmul)
+// 3) register tile sizes: used for register tiling and vectorization (3 sizes for matmul)
+table TileOptions {
+  work_group_sizes:[int64];
+  cache_tile_sizes:[int64];
+  register_tile_sizes:[int64];
+}
+root_type TileOptions;

--- a/matmul-iree/src/tiling/example/iree-tiling.json
+++ b/matmul-iree/src/tiling/example/iree-tiling.json
@@ -1,0 +1,4 @@
+{"work_group_sizes" : [128, 64],
+ "cache_tile_sizes" : [32, 8, 16],
+ "register_tile_sizes" : [4, 4, 4]
+}

--- a/matmul-iree/src/tiling/example/tile-matmul.sh
+++ b/matmul-iree/src/tiling/example/tile-matmul.sh
@@ -1,0 +1,3 @@
+../../../../build/flatbuffers-install/bin/flatc -b ../compile_options.fbs iree-tiling.json && \
+cat ../../matmul_MxNxK.mlir | sed 's@${M}@'"256"'@g' | sed 's@${N}@'"256"'@g' | sed 's@${K}@'"256"'@g' > matmul.mlir && \
+../../../../build/matmul-iree/src/tiling/add-tiling-attribute-pass matmul.mlir --compile-options "./iree-tiling.bin"

--- a/matmul/CMakeLists.txt
+++ b/matmul/CMakeLists.txt
@@ -184,6 +184,7 @@ if(USE_MKL)
   list(APPEND BACKENDS mkl)
 endif()
 if(USE_MLIR)
+  add_subdirectory(matmul-compile)
   list(APPEND BACKENDS mlir)
 endif()
 if(USE_NAIVE)
@@ -335,8 +336,6 @@ foreach(BACKEND ${BACKENDS})
     list(APPEND ALL_TARGETS ${MATMUL})
   endforeach()
 endforeach()
-
-add_subdirectory(matmul-compile)
 
 add_custom_target(run_all_tests
     ${CMAKE_SOURCE_DIR}/../mmperf.py


### PR DESCRIPTION
- matmul-iree/src/tiling contains files needed for adding lowering.config
  attribute to mhlo.dot op for tiling
 - The code to apply the pass to an input mlir file is in
   add-tiling-attribute-pass.cpp.  This requires an mlir file as a positional
   argument and a string for the path to the flatbuffer binary file containing
   tiling configs is passed through the argument --compile-options, i.e.
   > add-tiling-attribute-pass /path/to/input/mlir --compile-options /path/to/flatbuffer/binary
 - compile_options.fbs defines the flatbuffer schema for tiling
  - We currently use 3 variables
   - work group sizes: used for parallelizing spatial loops (2 sizes for matmul)
   - cache tile sizes: used for cache tiling (3 sizes for matmul)
   - register tile sizes: used for register tiling and vectorization (3 sizes for matmul)
  - A flatbuffer binary is created by passing the flatbuffer schema and a json file with
    the configs to the flatc executable, i.e.
    > flatc -b /path/to/fbs/file /path/to/json/file
 - The example directory contains an example json file and a bash script for using the
   add-tiling-attribute-pass to apply the pass to an mlir file

- Minor changes
 - in cmake/common.cmake default IREE_CUDA to OFF so that people don't need cuda to run
   compile to cpu with IREE
 - in matmul/CMakeLists.txt only add matmul-compile subdirectory if USE_MLIR is set to ON
   so that this doesn't break when only using USE_IREE=ON