### PR TITLE
Update iree tiling pass to work with latest IREE library

### DIFF
--- a/matmul-iree/src/CMakeLists.txt
+++ b/matmul-iree/src/CMakeLists.txt
@@ -42,6 +42,6 @@ foreach(MATRIX_SIZE ${MATRIX_SIZES})
   
 endforeach()
 
-#if(${IREE_DYLIB} OR ${IREE_VMVX})
-#  add_subdirectory(tiling)
-#endif()
+if(${IREE_DYLIB} OR ${IREE_VMVX})
+  add_subdirectory(tiling)
+endif()

--- a/matmul-iree/src/tiling/CMakeLists.txt
+++ b/matmul-iree/src/tiling/CMakeLists.txt
@@ -19,26 +19,28 @@ include(AddMLIR)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
-include_directories(${iree_SOURCE_DIR})
-include_directories(${iree_SOURCE_DIR}/third_party/llvm-project/llvm/include)
-include_directories(${iree_SOURCE_DIR}/third_party/llvm-project/mlir/include)
-include_directories(${iree_SOURCE_DIR}/third_party/mlir-hlo/include)
-include_directories(${iree_BINARY_DIR}/third_party/llvm-project/llvm/include)
-include_directories(${iree_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
-include_directories(${iree_BINARY_DIR})
+include_directories(${IREE_SOURCE_DIR})
+include_directories(${IREE_SOURCE_DIR}/third_party/llvm-project/llvm/include)
+include_directories(${IREE_SOURCE_DIR}/third_party/llvm-project/mlir/include)
+include_directories(${IREE_SOURCE_DIR}/third_party/mlir-hlo/include)
+include_directories(${IREE_BINARY_DIR}/third_party/llvm-project/llvm/include)
+include_directories(${IREE_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
+include_directories(${IREE_BINARY_DIR})
 
 set(LIBS
   ${dialect_libs}
   ${conversion_libs}
   MLIRExecutionEngine
   LLVMX86AsmParser
+  iree::compiler::Codegen::Dialect::IREECodegenDialect
   iree::compiler::Codegen::Utils
   iree::compiler::Dialect::HAL::IR
   iree::compiler::Dialect::HAL::IR::HALDialect
+  iree::compiler::Dialect::Util::IR
 )
 
 add_llvm_executable(add-tiling-attribute-pass add-tiling-attribute-pass.cpp)
 add_dependencies(add-tiling-attribute-pass run)
 llvm_update_compile_flags(add-tiling-attribute-pass)
-target_link_libraries(add-tiling-attribute-pass PRIVATE ${LIBS})
+target_link_libraries(add-tiling-attribute-pass PRIVATE stdc++fs ${LIBS})
 mlir_check_all_link_libraries(add-tiling-attribute-pass)


### PR DESCRIPTION
- This PR makes changes according to [this commit](https://github.com/google/iree/commit/6e825ae7a65f8984e901cb548dfa01ebce8eadc1). 
- It is built successfully by using command `cmake -GNinja -DCMAKE_CXX_COMPILER=clang++-11 -DCMAKE_C_COMPILER=clang-11 -DUSE_IREE=ON -DIREE_DYLIB=ON -B build .` However, when running the example in `mmperf/matmul-iree/src/tiling/example/ `, it has segment fault
```PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.	Program arguments: ../../../../build/matmul-iree/src/tiling/add-tiling-attribute-pass matmul.mlir --compile-options ./iree-tiling.bin
#0 0x000000000271df63 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (../../../../build/matmul-iree/src/tiling/add-tiling-attribute-pass+0x271df63)
#1 0x000000000271be7e llvm::sys::RunSignalHandlers() (../../../../build/matmul-iree/src/tiling/add-tiling-attribute-pass+0x271be7e)
#2 0x000000000271e40f SignalHandler(int) (../../../../build/matmul-iree/src/tiling/add-tiling-attribute-pass+0x271e40f)
#3 0x00007fb77fadb730 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x12730)
#4 0x000000000266c70b mlir::StorageUniquer::registerParametricStorageTypeImpl(mlir::TypeID, llvm::function_ref<void (mlir::StorageUniquer::BaseStorage*)>) (../../../../build/matmul-iree/src/tiling/add-tiling-attribute-pass+0x266c70b)
#5 0x00007fffa6037328 
Segmentation fault```