### PR TITLE
Fix error in generation of MLIR obj file

### DIFF
--- a/matmul/CMakeLists.txt
+++ b/matmul/CMakeLists.txt
@@ -147,7 +147,7 @@ function(compile_mlir_use_cuda mlir_prefix M N K)
   add_custom_command(OUTPUT ${OBJ}
     COMMAND cat ${CMAKE_BINARY_DIR}/mlir-objs/${mlir_prefix}.mlir |
     ${MLIR_OPT} --linalg-tile=\"loop-type=parallel tile-sizes=${TILE_SIZES_LOCAL}\" |
-    ${ML    ${} -fold-memref-subview-ops -canonicalize |
+    ${MLIR_OPT} -fold-memref-subview-ops -canonicalize |
     ${MLIR_OPT} -convert-vector-to-scf=full-unroll=true -convert-linalg-to-loops |
     ${MLIR_OPT} -gpu-kernel-outlining |
     ${MLIR_OPT} -lower-affine -convert-scf-to-std |


### PR DESCRIPTION
I noticed an error in my previous PR #73.
I am actually surprised that it ran without errors.
Also I am not entirely sure that CMake's [add_custom_command](https://cmake.org/cmake/help/latest/command/add_custom_command.html) runs the command in a shell. The piping may not be OK there. It is not explicitly stated, but for [execute_process](https://cmake.org/cmake/help/latest/command/execute_process.html) it is. I would assume they are consistent.